### PR TITLE
Adds analitza.nix and updates dependancies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /result
+tags

--- a/analitza.nix
+++ b/analitza.nix
@@ -1,0 +1,27 @@
+{ stdenv,
+  libsForQt5,
+  extra-cmake-modules,
+  eigen,
+  fetchurl,
+}:
+let
+  version = "21.12.2";
+in
+stdenv.mkDerivation {
+  pname = "analitza";
+  version = version;
+  dontWrapQtApps = true;
+
+  src = fetchurl {
+    url = "https://download.kde.org/stable/release-service/${version}/src/analitza-${version}.tar.xz";
+    sha256 = "a4c52d0ea51870495c2da25a58c7495af14e9d71a380d20aea9c1dd39de762aa";
+  };
+
+  buildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [
+    libsForQt5.qt5.qtdeclarative
+    libsForQt5.kdoctools
+    libsForQt5.qt5.qttools
+    eigen
+  ];
+}

--- a/cantor.nix
+++ b/cantor.nix
@@ -7,32 +7,37 @@
   extra-cmake-modules,
   python,
   luajit,
-  xorg,
-  sagemath,
+  R,
   shared-mime-info,
   cmake,
   fetchurl,
-  callPackage
+  callPackage,
 }:
 let
-  # analitza = callPackage ./analitza.nix {};
+  analitza = callPackage ./analitza.nix {};
+  version = "21.12.2";
 in
 stdenv.mkDerivation {
   pname = "cantor";
-  version = "21.12.2";
+  version = version;
 
   src = fetchurl {
-    url = "https://download.kde.org/stable/release-service/21.12.2/src/cantor-21.12.2.tar.xz";
+    url = "https://download.kde.org/stable/release-service/${version}/src/cantor-${version}.tar.xz";
     sha256 = "e85c356bf91896f56a4759270e45c202dd956a557b252772f18338fadaf6086f";
   };
 
-  nativeBuildInputs = [ extra-cmake-modules python shared-mime-info libsForQt5.qt5.wrapQtAppsHook ];
+  nativeBuildInputs = [
+    extra-cmake-modules
+    shared-mime-info
+    libsForQt5.qt5.wrapQtAppsHook
+    python
+    luajit
+    R
+  ];
   buildInputs = [
-    # analitza
+    analitza
     libspectre
     libqalculate
-    luajit
-    sagemath
     libsForQt5.kpty
     libsForQt5.ktexteditor
     libsForQt5.knewstuff

--- a/shell.nix
+++ b/shell.nix
@@ -15,8 +15,9 @@ mkShell {
   buildInputs = [
     cantor
     pythonDeps
-    sage
+    sagemath
     maxima
     octave
+    luajit
   ];
 }


### PR DESCRIPTION
Moves languages from buildInputs to nativeBuildInputs so that they'll be available at build time (so it gives us all the options) but not needed during runtime
Adds luajit and R but luajit doesn't actually work
Updates gitignore to ignore tags files (that's just just a nvim-tags thing though)